### PR TITLE
Avoid Linker issue w/gettimeofday() on Teensy 4.0

### DIFF
--- a/src/portable/teensy_common.cpp
+++ b/src/portable/teensy_common.cpp
@@ -416,6 +416,7 @@ int _getpid() {
     return reinterpret_cast<int>(::xTaskGetCurrentTaskHandle());
 }
 
+#if TEENSYDUINO < 158
 FLASHMEM int _gettimeofday(timeval* tv, void*) {
     const auto now_us { freertos::get_us() };
 #if defined(__has_include) && __has_include("freertos_time.h")
@@ -428,6 +429,7 @@ FLASHMEM int _gettimeofday(timeval* tv, void*) {
     timeradd(&off, &now, tv);
     return 0;
 }
+#endif
 
 FLASHMEM size_t xPortGetFreeHeapSize() {
     const struct mallinfo mi = ::mallinfo();


### PR DESCRIPTION
Teensyduino 1.58-beta2 now adds a gettimeofday() function in rtc.c of the Teensy4 core which now causes a linker error when using the library with the T4.

This was reported in a thread on the forum: https://forum.pjrc.com/threads/71198-Linker-issue-about-gettimeofday()-on-Teensy-4-0-with-FreeRTOS along with the recommended solution by @PaulStoffregen which this PR incorporates.  I did test it with the BLINK sketch and it works, ie. not linker error and the sketch runs correctly. 