### PR TITLE
Reduce yield delay

### DIFF
--- a/src/portable/teensy_common.cpp
+++ b/src/portable/teensy_common.cpp
@@ -304,7 +304,7 @@ FLASHMEM void yield() {
             portDATA_SYNC_BARRIER(); // mitigate arm errata #838869
         } else {
             ::xTaskNotify(freertos::g_yield_task, 0, eNoAction);
-            ::vTaskDelay(1);
+            ::vTaskDelay(0);
         }
     } else {
         freertos::yield();


### PR DESCRIPTION
I ran into an issue where this delay ends up being called in the middle of I2C transactions, significantly slowing down I2C transaction time.  See the threads on [platformio forums](https://community.platformio.org/t/i2c-on-teensy-with-freertos-having-an-unexpected-yield-behavior/53192) and [teensy forums](https://forum.pjrc.com/index.php?threads/intention-of-yield-in-endtransmission-and-requestfrom-methods.77533/).  

This change fixes the issue, though I haven't tested to see if it would cause issues by allowing a task to be preempted.  Or if there are any other effects that I'm not seeing. 